### PR TITLE
add AMZI_DIR environment variable for release config

### DIFF
--- a/dotnet/amzinet/PropertySheet.props
+++ b/dotnet/amzinet/PropertySheet.props
@@ -3,12 +3,16 @@
   <ImportGroup Label="PropertySheets" />
   <PropertyGroup Label="UserMacros">
     <AMZI_DEV_DIR>$(SolutionDir)..\</AMZI_DEV_DIR>
+    <AMZI_DIR>$(SolutionDir)..\</AMZI_DIR>
   </PropertyGroup>
   <PropertyGroup />
   <ItemDefinitionGroup />
   <ItemGroup>
     <BuildMacro Include="AMZI_DEV_DIR">
       <Value>$(AMZI_DEV_DIR)</Value>
+    </BuildMacro>
+    <BuildMacro Include="AMZI_DIR">
+      <Value>$(AMZI_DIR)</Value>
     </BuildMacro>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This changeset fixes the Release build configuration which is looking for an environment variable AMZI_DIR that is not defined. I have defined that variable to point to the same lib directory that Debug configuration is pointing to as both are using release package.

Close #3 